### PR TITLE
Alphabetically order categories in invoice by title.

### DIFF
--- a/billwarrior/invoice.py
+++ b/billwarrior/invoice.py
@@ -10,7 +10,8 @@ class Invoice(object):
 
         sorted_intervals = self._sort_by_category(intervals)
 
-        for category, intervals in sorted_intervals.items():
+        for category in sorted(sorted_intervals.keys(), key=config.text_for):
+            intervals = sorted_intervals[category]
             days = set([interval.get_date().date() for interval in intervals])
             intervals_by_day = {
                 day: [i for i in intervals if i.get_date().date() == day]


### PR DESCRIPTION
Thanks for the awesome Billwarrior software!

Every time I run Billwarrior for a given invoice, the category headings end up in a random order. This bugged me. So this pull request modifies the category order to always be deterministic and alphabetically ordered.

Please let me know if you'd like any changes.