### PR TITLE
Fix seconds to hours conversion in duration calculation.

### DIFF
--- a/billwarrior/invoice.py
+++ b/billwarrior/invoice.py
@@ -120,13 +120,9 @@ class LineItem(object):
     @property
     def duration(self):
         totsec = self.__duration.total_seconds()
-        h = totsec // 3600
-        m = (totsec % 3600) // 60
-        s = (totsec % 3600) % 60
+        hours = totsec / 3600.0
 
-        total = h + (m / 60) + (s / 6000)
-
-        return "{:.2f}".format(total)
+        return "{:.2f}".format(hours)
 
     @property
     def unit_price(self):

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -285,16 +285,12 @@ class LineItemTest(unittest.TestCase):
 
     def test_duration_should_display_decimal_value_of_hours_worked(self):
         duration = timedelta(
-            hours=randint(0, 8), minutes=randint(0, 59), seconds=randint(0, 59)
+            hours=8, minutes=51, seconds=59
         )
         line_item = LineItem(datetime.today(), duration, None)
 
         totsec = duration.total_seconds()
-        total = (
-            totsec // 3600
-            + (((totsec % 3600) // 60) / 60)
-            + (((totsec % 3600) % 60) / 6000)
-        )
+        total = totsec / 3600.0
 
         self.assertEqual(line_item.duration, "{:.2f}".format(total))
 


### PR DESCRIPTION
In the `LineItem` duration calculation, I believe that the conversion from seconds to hours is incorrect:

```python
        total = h + (m / 60) + (s / 6000)
```

That's because there are 60 seconds in an minute, and 60 minutes in an hour. Therefore, the correct conversion is actually:

```
        total = h + (m / 60) + (s / 3600)
```

However, with this change in place, I believe it's unnecessary to do the whole conversion from seconds to hours, minutes, and seconds in order to ultimately get decimal hours. A conversion from total seconds to decimal hours can be made directly.

The only benefit I can see of converting to hours, minutes, and seconds first would be to effectively "round" durations to whole seconds before converting them to decimal hours. That's unnecessary for a couple of reasons:

1. The current granularity of the returned duration is 0.01 hours, or 36 seconds. (Much larger than a single second.)
2. The ultimate unit of billing is hours, not seconds. Most invoicing agreements don't have a provision that billed time be converted to whole seconds before getting converted back to hours.

However, let me know if you don't agree with any of this!