### PR TITLE
Round invoiced hours values to one decimal place instead of two

### DIFF
--- a/billwarrior/invoice.py
+++ b/billwarrior/invoice.py
@@ -120,13 +120,9 @@ class LineItem(object):
     @property
     def duration(self):
         totsec = self.__duration.total_seconds()
-        h = totsec // 3600
-        m = (totsec % 3600) // 60
-        s = (totsec % 3600) % 60
+        hours = totsec / 3600.0
 
-        total = h + (m / 60) + (s / 6000)
-
-        return "{:.2f}".format(total)
+        return "{:.2f}".format(hours)
 
     @property
     def unit_price(self):

--- a/billwarrior/invoice.py
+++ b/billwarrior/invoice.py
@@ -126,7 +126,7 @@ class LineItem(object):
 
         total = h + (m / 60) + (s / 6000)
 
-        return "{:.2f}".format(total)
+        return "{:.1f}".format(round(total, 1))
 
     @property
     def unit_price(self):

--- a/etc/latex/invoice.cls
+++ b/etc/latex/invoice.cls
@@ -47,38 +47,37 @@
 \newcounter{hours} \newcounter{subhours} \newcounter{cost} \newcounter{subcost}
 \setcounter{hours}{0} \setcounter{subhours}{0} \setcounter{cost}{0} \setcounter{subcost}{0}
 
-% Formats inputed number with 2 digits after the decimal place
-\newcommand*{\formatNumber}[1]{\FPround{\cost}{#1}{2}\cost} %
+% Formats inputed dollars or hours with digits after the decimal place
+\newcommand*{\formatDollars}[1]{\FPround{\cost}{#1}{2}\cost} %
+\newcommand*{\formatHours}[1]{\FPround{\cost}{#1}{1}\cost} %
 
 % Returns the total of counter
-\newcommand*{\total}[1]{\FPdiv{\t}{\arabic{#1}}{1000}\formatNumber{\t}}
+\newcommand*{\totalDollars}[1]{\FPdiv{\t}{\arabic{#1}}{1000000}\formatDollars{\t}}
+\newcommand*{\totalHours}[1]{\FPdiv{\t}{\arabic{#1}}{1000000}\formatHours{\t}}
 
 % Create an invoice table
 \newenvironment{invoiceTable}{
     % Create a new row from title, unit quantity, unit rate, and unit name
     \newcommand*{\unitrow}[4]{%
-         \addtocounter{cost}{1000 * \real{##2} * \real{##3}}%
-         \addtocounter{subcost}{1000 * \real{##2} * \real{##3}}%
-         ##1 & \formatNumber{##2} ##4 & \$\formatNumber{##3} & \$\FPmul{\cost}{##2}{##3}\formatNumber{\cost}%
+         \addtocounter{cost}{1000000 * \real{##2} * \real{##3}}%
+         \addtocounter{subcost}{1000000 * \real{##2} * \real{##3}}%
+         ##1 & \formatHours{##2} ##4 & \$\formatDollars{##3} & \$\FPmul{\cost}{##2}{##3}\formatDollars{\cost}%
          \\
     }
     % Create a new row from title and expense amount
     \newcommand*{\feerow}[2]{%
-         \addtocounter{cost}{1000 * \real{##2}}%
-         \addtocounter{subcost}{1000 * \real{##2}}%
-         ##1 & & \$\formatNumber{##2} & \$\FPmul{\cost}{##2}{1}\formatNumber{\cost}%
+         \addtocounter{cost}{1000000 * \real{##2}}%
+         \addtocounter{subcost}{1000000 * \real{##2}}%
+         ##1 & & \$\formatHours{##2} & \$\FPmul{\cost}{##2}{1}\formatDollars{\cost}%
          \\
     }
 
     \newcommand{\subtotalNoStar}{
-        {\bf Subtotal} & {\bf \total{subhours} hours} &  & {\bf \$\total{subcost}}
-        \setcounter{subcost}{0}
-        \setcounter{subhours}{0}
+        Subtotal & \totalHours{subhours} hours &  & \$\totalDollars{subcost}\setcounter{subcost}{0}\setcounter{subhours}{0}
         \\*[1.5ex]
     }
     \newcommand{\subtotalStar}{
-        {\bf Subtotal} & & & {\bf \$\total{subcost}}
-        \setcounter{subcost}{0}
+        Subtotal & & & \$\totalHours{subcost}\setcounter{subcost}{0}
         \\*[1.5ex]
     }
     \newcommand{\subtotal}{
@@ -90,8 +89,8 @@
 
     % Create a new row from date and hours worked (use stored fee type and hourly rate)
     \newcommand*{\hourrow}[3]{%
-        \addtocounter{hours}{1000 * \real{##2}}%
-        \addtocounter{subhours}{1000 * \real{##2}}%
+        \addtocounter{hours}{1000000 * \real{##2}}%
+        \addtocounter{subhours}{1000000 * \real{##2}}%
         \unitrow{##1}{##2}{##3}{hours}%
     }
     \renewcommand{\tabcolsep}{0.8ex}
@@ -104,6 +103,6 @@
     \endhead
 }{
     \hline\hline\hline
-    {\bf Balance Due} & & & {\bf \$\total{cost}} \\
+    {\bf Balance Due} & & & {\bf \$\totalDollars{cost}} \\
     \end{longtable}
 }

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -285,16 +285,12 @@ class LineItemTest(unittest.TestCase):
 
     def test_duration_should_display_decimal_value_of_hours_worked(self):
         duration = timedelta(
-            hours=randint(0, 8), minutes=randint(0, 59), seconds=randint(0, 59)
+            hours=8, minutes=51, seconds=59
         )
         line_item = LineItem(datetime.today(), duration, None)
 
         totsec = duration.total_seconds()
-        total = (
-            totsec // 3600
-            + (((totsec % 3600) // 60) / 60)
-            + (((totsec % 3600) % 60) / 6000)
-        )
+        total = totsec / 3600.0
 
         self.assertEqual(line_item.duration, "{:.2f}".format(total))
 

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -296,7 +296,7 @@ class LineItemTest(unittest.TestCase):
             + (((totsec % 3600) % 60) / 6000)
         )
 
-        self.assertEqual(line_item.duration, "{:.2f}".format(total))
+        self.assertEqual(line_item.duration, "{:.1f}".format(total))
 
     def test_unit_price_should_be_displayed_as_is(self):
         unit_price = randint(0, 200) + randint(0, 99) * 0.1


### PR DESCRIPTION
Consider this a proposal that happens to have a pull request attached!

I've found in the consulting world that it's much more common to bill in tenths of an hour (6 minutes) rather than hundredths (36 seconds!). So this change alters both the Python invoice code and the LaTeX class file to round to 0.1 hours rather than 0.01.

I left the rounding for dollar amounts untouched, except to fix an apparent bug in which larger dollar subtotals may be calculated incorrectly, because only four digits are used in the LaTeX class file for subtotalling (and I believe that includes cents). So this pull request increases the number of digits used.

Testing done: Generated a fairly complex invoice with these changes and observed that all hours values now show up in tenth of an hour increments. Manually ran through the hours _and_ dollars subtotals with a calculator to confirm that they're correct.