### PR TITLE
Second attempt at fixing timezone test issues

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,6 @@ timew-report = "<1.3"
 
 [dev-packages]
 pytest = "*"
-pytest-freezegun = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "008ea2855063155133d59a7470bd38d965c8028f0b40c74f427c96cccd61ef52"
+            "sha256": "9041881b029e904d14ec563c5cdde0731eb0ffbc0f28bf37dc5ff30dd22e3556"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -48,14 +48,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.2.0"
-        },
-        "freezegun": {
-            "hashes": [
-                "sha256:177f9dd59861d871e27a484c3332f35a6e3f5d14626f2bf91be37891f18927f3",
-                "sha256:2ae695f7eb96c62529f03a038461afe3c692db3465e215355e1bb4b0ab408712"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==1.1.0"
         },
         "importlib-metadata": {
             "hashes": [
@@ -111,30 +103,6 @@
             ],
             "index": "pypi",
             "version": "==6.2.5"
-        },
-        "pytest-freezegun": {
-            "hashes": [
-                "sha256:19c82d5633751bf3ec92caa481fb5cffaac1787bd485f0df6436fd6242176949",
-                "sha256:5318a6bfb8ba4b709c8471c94d0033113877b3ee02da5bfcd917c1889cde99a7"
-            ],
-            "index": "pypi",
-            "version": "==0.4.2"
-        },
-        "python-dateutil": {
-            "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.2"
-        },
-        "six": {
-            "hashes": [
-                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.16.0"
         },
         "toml": {
             "hashes": [

--- a/tests/testsupport.py
+++ b/tests/testsupport.py
@@ -15,4 +15,3 @@ def give_interval(day=None, tags=[]):
     end = start + timedelta(0, randint(60 * 5, 60 * 60 * 2))  # up to 2h
 
     return TimeWarriorInterval(start.strftime(DT_FORMAT), end.strftime(DT_FORMAT), tags)
-


### PR DESCRIPTION
This is a followup to #10. It turns out that `freezegun` does not yet
support `dateutil`'s `tzlocal`, which is used by `timew-report`
[here]. [This comment] on the `freezegun` repository provides a context
manager solution that can be used for now. This change properly fixes #6.

[here]: https://github.com/lauft/timew-report/blob/c972357a44640c7a5f803d79fc77ca597e1b22f0/timewreport/interval.py#L49
[This comment]: https://github.com/lauft/timew-report/blob/c972357a44640c7a5f803d79fc77ca597e1b22f0/timewreport/interval.py#L49