### PR TITLE
Upgrade the version of `timew-report`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-timew-report = "<1.3"
+timew-report = ">=1.4"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9041881b029e904d14ec563c5cdde0731eb0ffbc0f28bf37dc5ff30dd22e3556"
+            "sha256": "c5c114d75da1f3399f8c5bbd0d877fdd08a5b9d2bb6734b390e2c5a9dc4242a1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,29 @@
         ]
     },
     "default": {
+        "deprecation": {
+            "hashes": [
+                "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff",
+                "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a"
+            ],
+            "version": "==2.1.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
+                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
@@ -34,10 +57,11 @@
         },
         "timew-report": {
             "hashes": [
-                "sha256:cc3d07f8dcc7862c7d4759f61a3cbd2ccafbc22de9724fb9702edb6eb0e624fd"
+                "sha256:439ec4dda62215ff347971095d99566678be3c9e3c5dbecdb8bed51fd4422f90",
+                "sha256:b50cbda98ebc146cd3bb39312ad8c5c0fe066d8785952dd85623a4032c5c9b75"
             ],
             "index": "pypi",
-            "version": "==1.0.2"
+            "version": "==1.4.0"
         }
     },
     "develop": {

--- a/billwarrior/invoice.py
+++ b/billwarrior/invoice.py
@@ -12,9 +12,9 @@ class Invoice(object):
 
         for category in sorted(sorted_intervals.keys(), key=config.text_for):
             intervals = sorted_intervals[category]
-            days = set([interval.get_date().date() for interval in intervals])
+            days = set([interval.get_start_date() for interval in intervals])
             intervals_by_day = {
-                day: [i for i in intervals if i.get_date().date() == day]
+                day: [i for i in intervals if i.get_start_date() == day]
                 for day in days
             }
 

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -67,8 +67,8 @@ class InvoiceTest(unittest.TestCase):
         items = invoice.items()
 
         expected_a, expected_b = (
-            ItemCategory("Consulting & Research", {a.get_date().date(): [a]}, 0.0),
-            ItemCategory("Travel", {b.get_date().date(): [b]}, 0.0),
+            ItemCategory("Consulting & Research", {a.get_start_date(): [a]}, 0.0),
+            ItemCategory("Travel", {b.get_start_date(): [b]}, 0.0),
         )
 
         self.assertEqual(len(items), 2)
@@ -91,7 +91,7 @@ class InvoiceTest(unittest.TestCase):
 
             expected = ItemCategory(
                 "Consulting & Research",
-                {same_day.date(): [a, b], c.get_date().date(): [c]},
+                {same_day.date(): [a, b], c.get_start_date(): [c]},
                 0.0,
             )
 
@@ -155,12 +155,12 @@ class InvoiceTest(unittest.TestCase):
         expected_a, expected_b = (
             ItemCategory(
                 "Consulting & Research",
-                {a.get_date().date(): [a]},
+                {a.get_start_date(): [a]},
                 billw_config.rate_for(category_a),
             ),
             ItemCategory(
                 "Software Development",
-                {b.get_date().date(): [b]},
+                {b.get_start_date(): [b]},
                 billw_config.rate_for(category_b),
             ),
         )
@@ -189,12 +189,12 @@ class InvoiceTest(unittest.TestCase):
         expected_a, expected_b = (
             ItemCategory(
                 "Consulting & Research",
-                {a.get_date().date(): [a]},
+                {a.get_start_date(): [a]},
                 billw_config.rate_for(category_a),
             ),
             ItemCategory(
                 "Software Development",
-                {b.get_date().date(): [b]},
+                {b.get_start_date(): [b]},
                 billw_config.rate_for(category_b),
             ),
         )
@@ -219,12 +219,12 @@ class InvoiceTest(unittest.TestCase):
         expected_a, expected_b = (
             ItemCategory(
                 "Consulting & Research",
-                {a.get_date().date(): [a]},
+                {a.get_start_date(): [a]},
                 billw_config.rate_for(category_a),
             ),
             ItemCategory(
                 "Software Development",
-                {b.get_date().date(): [b]},
+                {b.get_start_date(): [b]},
                 billw_config.rate_for(category_b),
             ),
         )
@@ -253,7 +253,7 @@ class ItemCategoryTest(unittest.TestCase):
                 [tests.give_interval(a_day + timedelta(days=2))],
                 [tests.give_interval(a_day + timedelta(days=3))],
             ]
-            intervals_by_day = {entry[0].get_date().date(): entry for entry in entries}
+            intervals_by_day = {entry[0].get_start_date(): entry for entry in entries}
 
             category = ItemCategory("arbitray category", intervals_by_day, 0.0)
 
@@ -265,11 +265,11 @@ class ItemCategoryTest(unittest.TestCase):
             [tests.give_interval()],
             [tests.give_interval()],
         ]
-        dates = [entry[0].get_date().date() for entry in entries]
+        dates = [entry[0].get_start_date() for entry in entries]
 
         category = ItemCategory("arbitray category", dict(zip(dates, entries)), 0.0)
 
-        sorted_date_list = sorted([entry[0].get_date().date() for entry in entries])
+        sorted_date_list = sorted([entry[0].get_start_date() for entry in entries])
         self.assertListEqual(
             [
                 datetime.strptime(line_item.date, "%B %d, %Y").date()
@@ -280,7 +280,7 @@ class ItemCategoryTest(unittest.TestCase):
 
     def test_str_should_display_header_line_items_and_subtotal_as_latex_output(self):
         a, b = tests.give_interval(), tests.give_interval()
-        entries = {a.get_date().date(): [a], b.get_date().date(): [b]}
+        entries = {a.get_start_date(): [a], b.get_start_date(): [b]}
 
         category = ItemCategory("arbitrary category", entries, 0.0)
 
@@ -289,8 +289,8 @@ class ItemCategoryTest(unittest.TestCase):
                 "\\feetype{%s}\n" % category.header,
                 "".join(
                     [
-                        "%s\n" % LineItem(i.get_date(), i.get_duration(), 0.0)
-                        for i in sorted([a, b], key=lambda x: x.get_date())
+                        "%s\n" % LineItem(i.get_start_date(), i.get_duration(), 0.0)
+                        for i in sorted([a, b], key=lambda x: x.get_start_date())
                     ]
                 ),
                 "\\subtotal\n",

--- a/tests/testsupport.py
+++ b/tests/testsupport.py
@@ -14,4 +14,4 @@ def give_interval(day=None, tags=[]):
 
     end = start + timedelta(0, randint(60 * 5, 60 * 60 * 2))  # up to 2h
 
-    return TimeWarriorInterval(start.strftime(DT_FORMAT), end.strftime(DT_FORMAT), tags)
+    return TimeWarriorInterval(start.strftime(DT_FORMAT), end.strftime(DT_FORMAT), tags, None)


### PR DESCRIPTION
The version of `timew-report` was restricted in #10 to deal with failing
tests. This change updates the version required by the `Pipfile` and
makes the following code changes:

1. Update a test helper to pass in a value for the new required argument
   `annotation`. This is not used by the test suite, so the helper uses
   `None` for now.

2. Addresses some breaking changes and deprecation warnings in
   `get_date` released in [1.4]. `get_date` now returns a `date` instead
   of a `datetime`. `get_start_date` offers the same implementation that
   `get_date` used to, so no logic has changed here, and this avoids
   deprecation warnings.

[1.4]: lauft/timew-report@a964eb3

---

Note that this pull request is branched from #13. These changes aren't actually related, but I wanted a stable testing state to base this upgrade on. The diff against `master` will be smaller once that other change is merged.